### PR TITLE
Feat: 웨이팅 예약하기 API 구현 / 웨이팅 조회 API 구현 예정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,6 +41,8 @@ dependencies {
     testImplementation 'org.springframework.security:spring-security-test'
     testImplementation 'org.junit.jupiter:junit-jupiter:5.10.0'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+    testImplementation 'org.assertj:assertj-core:3.21.0'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/fourchelin/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/fourchelin/common/exception/GlobalExceptionHandler.java
@@ -3,7 +3,9 @@ package com.example.fourchelin.common.exception;
 import com.example.fourchelin.domain.store.exception.StoreException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 import java.util.HashMap;
@@ -25,5 +27,16 @@ public class GlobalExceptionHandler {
         errorResponse.put("message", message);
 
         return new ResponseEntity<>(errorResponse, status);
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public ResponseEntity<Map<String, String>> handleValidationExceptions(MethodArgumentNotValidException ex) {
+        Map<String, String> errors = new HashMap<>();
+
+        ex.getBindingResult().getFieldErrors().forEach(error ->
+                errors.put(error.getField(), error.getDefaultMessage())
+        );
+        return new ResponseEntity<>(errors, HttpStatus.BAD_REQUEST);
     }
 }

--- a/src/main/java/com/example/fourchelin/domain/waiting/controller/WaitingController.java
+++ b/src/main/java/com/example/fourchelin/domain/waiting/controller/WaitingController.java
@@ -1,5 +1,6 @@
 package com.example.fourchelin.domain.waiting.controller;
 
+import com.example.fourchelin.common.security.UserDetailsImpl;
 import com.example.fourchelin.common.template.RspTemplate;
 import com.example.fourchelin.domain.waiting.dto.request.WaitingRequest;
 import com.example.fourchelin.domain.waiting.dto.response.WaitingResponse;
@@ -7,6 +8,7 @@ import com.example.fourchelin.domain.waiting.service.WaitingService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -20,8 +22,9 @@ public class WaitingController {
 
     @PostMapping
     public RspTemplate<WaitingResponse> createWaiting(
-            @Valid @RequestBody WaitingRequest request) {   // 유저 확인 추가
-        WaitingResponse response = waitingService.createWaiting(request, 1L);
+            @Valid @RequestBody WaitingRequest request,
+            @AuthenticationPrincipal UserDetailsImpl userDetails) {
+        WaitingResponse response = waitingService.createWaiting(request, userDetails.getMember());
         return new RspTemplate<>(HttpStatus.CREATED, "성공적으로 웨이팅 신청되었습니다.", response);
     }
 }

--- a/src/main/java/com/example/fourchelin/domain/waiting/controller/WaitingController.java
+++ b/src/main/java/com/example/fourchelin/domain/waiting/controller/WaitingController.java
@@ -16,7 +16,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/waiting")
+@RequestMapping("/api/waitings")
 public class WaitingController {
     private final WaitingService waitingService;
 

--- a/src/main/java/com/example/fourchelin/domain/waiting/controller/WaitingController.java
+++ b/src/main/java/com/example/fourchelin/domain/waiting/controller/WaitingController.java
@@ -1,0 +1,27 @@
+package com.example.fourchelin.domain.waiting.controller;
+
+import com.example.fourchelin.common.template.RspTemplate;
+import com.example.fourchelin.domain.waiting.dto.request.WaitingRequest;
+import com.example.fourchelin.domain.waiting.dto.response.WaitingResponse;
+import com.example.fourchelin.domain.waiting.service.WaitingService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/waiting")
+public class WaitingController {
+    private final WaitingService waitingService;
+
+    @PostMapping
+    public RspTemplate<WaitingResponse> createWaiting(
+            @Valid @RequestBody WaitingRequest request) {   // 유저 확인 추가
+        WaitingResponse response = waitingService.createWaiting(request, 1L);
+        return new RspTemplate<>(HttpStatus.CREATED, "성공적으로 웨이팅 신청되었습니다.", response);
+    }
+}

--- a/src/main/java/com/example/fourchelin/domain/waiting/dto/request/WaitingRequest.java
+++ b/src/main/java/com/example/fourchelin/domain/waiting/dto/request/WaitingRequest.java
@@ -14,4 +14,5 @@ public record WaitingRequest(
         long personnel,
         @NotNull
         Long storeId
-) { }
+) {
+}

--- a/src/main/java/com/example/fourchelin/domain/waiting/dto/request/WaitingRequest.java
+++ b/src/main/java/com/example/fourchelin/domain/waiting/dto/request/WaitingRequest.java
@@ -1,0 +1,15 @@
+package com.example.fourchelin.domain.waiting.dto.request;
+
+import com.example.fourchelin.domain.waiting.enums.WaitingMealType;
+import com.example.fourchelin.domain.waiting.enums.WaitingType;
+import jakarta.validation.constraints.NotBlank;
+
+public record WaitingRequest(
+        @NotBlank
+        WaitingType waitingType,
+        @NotBlank
+        WaitingMealType mealType,
+        long personnel,
+        Long storeId
+) {
+}

--- a/src/main/java/com/example/fourchelin/domain/waiting/dto/request/WaitingRequest.java
+++ b/src/main/java/com/example/fourchelin/domain/waiting/dto/request/WaitingRequest.java
@@ -2,14 +2,16 @@ package com.example.fourchelin.domain.waiting.dto.request;
 
 import com.example.fourchelin.domain.waiting.enums.WaitingMealType;
 import com.example.fourchelin.domain.waiting.enums.WaitingType;
-import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
 
 public record WaitingRequest(
-        @NotBlank
+        @NotNull
         WaitingType waitingType,
-        @NotBlank
+        @NotNull
         WaitingMealType mealType,
+        @Min(1)
         long personnel,
+        @NotNull
         Long storeId
-) {
-}
+) { }

--- a/src/main/java/com/example/fourchelin/domain/waiting/dto/response/WaitingResponse.java
+++ b/src/main/java/com/example/fourchelin/domain/waiting/dto/response/WaitingResponse.java
@@ -1,0 +1,28 @@
+package com.example.fourchelin.domain.waiting.dto.response;
+
+import com.example.fourchelin.domain.waiting.entity.Waiting;
+import com.example.fourchelin.domain.waiting.enums.WaitingMealType;
+import com.example.fourchelin.domain.waiting.enums.WaitingStatus;
+import com.example.fourchelin.domain.waiting.enums.WaitingType;
+import lombok.Builder;
+
+@Builder
+public record WaitingResponse(
+        String storeName,
+        WaitingMealType mealType,
+        long personnel,
+        WaitingType waitingType,
+        long waitingNum,
+        WaitingStatus waitingStatus
+) {
+    public static WaitingResponse from(Waiting waiting) {
+        return WaitingResponse.builder()
+                .storeName(waiting.getStore().getStoreName())
+                .mealType(waiting.getMealType())
+                .personnel(waiting.getPersonnel())
+                .waitingType(waiting.getType())
+                .waitingNum(waiting.getWaitingNumber())
+                .waitingStatus(waiting.getStatus())
+                .build();
+    }
+}

--- a/src/main/java/com/example/fourchelin/domain/waiting/entity/Waiting.java
+++ b/src/main/java/com/example/fourchelin/domain/waiting/entity/Waiting.java
@@ -1,6 +1,7 @@
 package com.example.fourchelin.domain.waiting.entity;
 
 import com.example.fourchelin.common.baseentity.Timestamped;
+import com.example.fourchelin.domain.member.entity.Member;
 import com.example.fourchelin.domain.store.entity.Store;
 import com.example.fourchelin.domain.waiting.enums.WaitingMealType;
 import com.example.fourchelin.domain.waiting.enums.WaitingStatus;

--- a/src/main/java/com/example/fourchelin/domain/waiting/entity/Waiting.java
+++ b/src/main/java/com/example/fourchelin/domain/waiting/entity/Waiting.java
@@ -19,9 +19,9 @@ public class Waiting extends Timestamped {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-/*    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id")
-    private User user;*/
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "store_id")
@@ -38,17 +38,17 @@ public class Waiting extends Timestamped {
     private WaitingStatus status;
 
     @Column(name = "waiting_number")
-    private int waitingNumber;  // 대기 번호
-    private int personnel;  // 인원 수
+    private long waitingNumber;  // 대기 번호
+    private long personnel;  // 인원 수
 
-/*    @Builder
-    public Waiting(User user, Store store, WaitingType type, WaitingMealType mealType, WaitingStatus status, int waitingNumber, int personnel) {
-        this.user = user;
+    @Builder
+    public Waiting(Member member, Store store, WaitingType type, WaitingMealType mealType, WaitingStatus status, long waitingNumber, long personnel) {
+        this.member = member;
         this.store = store;
         this.type = type;
         this.mealType = mealType;
         this.status = status;
         this.waitingNumber = waitingNumber;
         this.personnel = personnel;
-    }*/
+    }
 }

--- a/src/main/java/com/example/fourchelin/domain/waiting/repository/WaitingRepository.java
+++ b/src/main/java/com/example/fourchelin/domain/waiting/repository/WaitingRepository.java
@@ -1,7 +1,10 @@
 package com.example.fourchelin.domain.waiting.repository;
 
+import com.example.fourchelin.domain.member.entity.Member;
 import com.example.fourchelin.domain.waiting.entity.Waiting;
+import com.example.fourchelin.domain.waiting.enums.WaitingStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface WaitingRepository extends JpaRepository<Waiting, Long> {
+    boolean existsByMemberAndStatus(Member member, WaitingStatus waitingStatus);
 }

--- a/src/main/java/com/example/fourchelin/domain/waiting/service/WaitingService.java
+++ b/src/main/java/com/example/fourchelin/domain/waiting/service/WaitingService.java
@@ -1,0 +1,36 @@
+package com.example.fourchelin.domain.waiting.service;
+
+import com.example.fourchelin.domain.waiting.dto.request.WaitingRequest;
+import com.example.fourchelin.domain.waiting.dto.response.WaitingResponse;
+import com.example.fourchelin.domain.waiting.entity.Waiting;
+import com.example.fourchelin.domain.waiting.enums.WaitingStatus;
+import com.example.fourchelin.domain.waiting.repository.WaitingRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class WaitingService {
+
+    private final WaitingRepository waitingRepository;
+
+    @Transactional
+    public WaitingResponse createWaiting(WaitingRequest request, Long memberId) {
+        // 유저 관련 정보 확인 및 해당 전화번호로 이미 예약된 사항이 있는 지 확인하는 로직
+        // 예약된 사항이 있다면 예외 처리
+        Waiting waiting = Waiting.builder()
+                .member(memberId)
+                .store(request.storeId())
+                .type(request.waitingType())
+                .mealType(request.mealType())
+                .status(WaitingStatus.WAITING)
+                .waitingNum()   // 대기 번호 부여 하는 법 고려
+                .personnel(request.personnel())
+                .build();
+
+        waitingRepository.save(waiting);
+        return WaitingResponse.from(waiting);
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -9,7 +9,7 @@ spring:
   jpa:
     database: mysql
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
     show-sql: true
     properties:
       hibernate:

--- a/src/test/java/com/example/fourchelin/domain/waiting/service/WaitingServiceTest.java
+++ b/src/test/java/com/example/fourchelin/domain/waiting/service/WaitingServiceTest.java
@@ -42,7 +42,7 @@ class WaitingServiceTest {
     void createWaiting_Success() {
         // given
         WaitingRequest request = new WaitingRequest(WaitingType.MOBILE, WaitingMealType.DINE_IN, 2, 1L);
-        Member member = createMember("010-1234-5678", "nickname", "password", MemberRole.USER);
+        Member member = createMember("01012345678", "nickname", "password", MemberRole.USER);
         Store store = new Store(1L, "Test Store", "서울시 강남구");
 
         when(waitingRepository.existsByMemberAndStatus(member, WaitingStatus.WAITING)).thenReturn(false);
@@ -63,7 +63,7 @@ class WaitingServiceTest {
     void createWaiting_AlreadyWaiting_Exception() {
         // given
         WaitingRequest request = new WaitingRequest(WaitingType.MOBILE, WaitingMealType.DINE_IN, 2, 1L);
-        Member member = createMember("010-1234-5678", "nickname", "password", MemberRole.USER);
+        Member member = createMember("01012345678", "nickname", "password", MemberRole.USER);
 
         when(waitingRepository.existsByMemberAndStatus(member, WaitingStatus.WAITING)).thenReturn(true);
 
@@ -78,7 +78,7 @@ class WaitingServiceTest {
     void createWaiting_StoreNotFound_Exception() {
         // given
         WaitingRequest request = new WaitingRequest(WaitingType.MOBILE, WaitingMealType.DINE_IN, 2, 1L);
-        Member member = createMember("010-1234-5678", "nickname", "password", MemberRole.USER);
+        Member member = createMember("01012345678", "nickname", "password", MemberRole.USER);
 
         when(waitingRepository.existsByMemberAndStatus(member, WaitingStatus.WAITING)).thenReturn(false);
         when(storeRepository.findById(request.storeId())).thenReturn(Optional.empty());

--- a/src/test/java/com/example/fourchelin/domain/waiting/service/WaitingServiceTest.java
+++ b/src/test/java/com/example/fourchelin/domain/waiting/service/WaitingServiceTest.java
@@ -1,0 +1,91 @@
+package com.example.fourchelin.domain.waiting.service;
+
+import com.example.fourchelin.domain.member.entity.Member;
+import com.example.fourchelin.domain.member.enums.MemberRole;
+import com.example.fourchelin.domain.store.entity.Store;
+import com.example.fourchelin.domain.store.exception.StoreException;
+import com.example.fourchelin.domain.store.repository.StoreRepository;
+import com.example.fourchelin.domain.waiting.dto.request.WaitingRequest;
+import com.example.fourchelin.domain.waiting.dto.response.WaitingResponse;
+import com.example.fourchelin.domain.waiting.entity.Waiting;
+import com.example.fourchelin.domain.waiting.enums.WaitingMealType;
+import com.example.fourchelin.domain.waiting.enums.WaitingStatus;
+import com.example.fourchelin.domain.waiting.enums.WaitingType;
+import com.example.fourchelin.domain.waiting.repository.WaitingRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static com.example.fourchelin.domain.member.entity.Member.createMember;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class WaitingServiceTest {
+    @Mock
+    private WaitingRepository waitingRepository;
+
+    @Mock
+    private StoreRepository storeRepository;
+
+    @InjectMocks
+    private WaitingService waitingService;
+
+    @Test
+    @DisplayName("웨이팅 신청 성공")
+    void createWaiting_Success() {
+        // given
+        WaitingRequest request = new WaitingRequest(WaitingType.MOBILE, WaitingMealType.DINE_IN, 2, 1L);
+        Member member = createMember("010-1234-5678", "nickname", "password", MemberRole.USER);
+        Store store = new Store(1L, "Test Store", "서울시 강남구");
+
+        when(waitingRepository.existsByMemberAndStatus(member, WaitingStatus.WAITING)).thenReturn(false);
+        when(storeRepository.findById(request.storeId())).thenReturn(Optional.of(store));
+
+        // when
+        WaitingResponse response = waitingService.createWaiting(request, member);
+
+        // then
+        assertThat(response).isNotNull();
+        assertThat(response.storeName()).isEqualTo("Test Store");
+        assertThat(response.waitingStatus()).isEqualTo(WaitingStatus.WAITING);
+        verify(waitingRepository, times(1)).save(any(Waiting.class));
+    }
+
+    @Test
+    @DisplayName("이미 대기중인 경우 예외 발생")
+    void createWaiting_AlreadyWaiting_Exception() {
+        // given
+        WaitingRequest request = new WaitingRequest(WaitingType.MOBILE, WaitingMealType.DINE_IN, 2, 1L);
+        Member member = createMember("010-1234-5678", "nickname", "password", MemberRole.USER);
+
+        when(waitingRepository.existsByMemberAndStatus(member, WaitingStatus.WAITING)).thenReturn(true);
+
+        // when & then
+        assertThatThrownBy(() -> waitingService.createWaiting(request, member))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("이미 예약된 사항이 존재합니다.");
+    }
+
+    @Test
+    @DisplayName("가게가 없는 경우 예외 발생")
+    void createWaiting_StoreNotFound_Exception() {
+        // given
+        WaitingRequest request = new WaitingRequest(WaitingType.MOBILE, WaitingMealType.DINE_IN, 2, 1L);
+        Member member = createMember("010-1234-5678", "nickname", "password", MemberRole.USER);
+
+        when(waitingRepository.existsByMemberAndStatus(member, WaitingStatus.WAITING)).thenReturn(false);
+        when(storeRepository.findById(request.storeId())).thenReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> waitingService.createWaiting(request, member))
+                .isInstanceOf(StoreException.class)
+                .hasMessage("해당 가게가 존재하지 않습니다.");
+    }
+}


### PR DESCRIPTION
## 🔎 작업 내용
- Validation에서 걸러진 에러를 globalExceptionHandler에서 처리
- 웨이팅 예약하기 API 구현
- Member와 이어서 재수정

## ➕ 이슈 링크
- #9 

## 📸 스크린샷(선택)
![image](https://github.com/user-attachments/assets/602a4eb2-3f80-4131-90cc-bc62aecee241)

## 📝 체크리스트
- [x] 브랜치 이름은 `issue/이슈번호` 형식으로 작성했는가?
- [x] 커밋 메시지는 `[#이슈번호] Feat: 커밋 내용` 형식으로 작성했는가?
- [x] 코드에 주석은 최대한 없앴는가?
- [x] 코드 리뷰어의 피드백을 반영했는가?
- [x] 테스트를 진행했는가?
- [x] 테스트 코드를 작성했는가?
- [x] 불필요한 주석은 제거했는가?
