### PR TITLE
[#22] fix: /api/searches에 익명 사용자 접근 허용 가능하도록 Filter 수정

### DIFF
--- a/src/main/java/com/example/fourchelin/common/filter/MemberAuthenticationFilter.java
+++ b/src/main/java/com/example/fourchelin/common/filter/MemberAuthenticationFilter.java
@@ -31,7 +31,12 @@ public class MemberAuthenticationFilter extends OncePerRequestFilter {
         HttpSession session = request.getSession(false); // Session 정보를 가져오는데 없으면 세션을 새로 생성X
 
         if (session == null) {
-            throw new MemberException("requestURI : " + requestURI + "/인증되지 않은 사용자 입니다.");
+            if(requestURI.startsWith("/api/searches")){ // /api/searches 로 시작하는 API는 익명 사용자도 접근이 가능
+                chain.doFilter(request, response);
+
+            } else {
+                throw new MemberException("requestURI : " + requestURI + "/인증되지 않은 사용자 입니다.");
+            }
         }
 
         Member member = (Member) session.getAttribute("LOGIN_MEMBER");

--- a/src/main/java/com/example/fourchelin/domain/member/controller/MemberController.java
+++ b/src/main/java/com/example/fourchelin/domain/member/controller/MemberController.java
@@ -6,6 +6,7 @@ import com.example.fourchelin.domain.member.dto.request.SignupRequest;
 import com.example.fourchelin.domain.member.dto.response.LoginResponse;
 import com.example.fourchelin.domain.member.dto.response.SignupResponse;
 import com.example.fourchelin.domain.member.service.MemberService;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpSession;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -30,8 +31,9 @@ public class MemberController {
     }
 
     @PostMapping("/login")
-    public RspTemplate<LoginResponse> login(HttpSession session, @RequestBody @Valid LoginRequest req) {
+    public RspTemplate<LoginResponse> login(HttpServletRequest httpRequest, @RequestBody @Valid LoginRequest req) {
 
+        HttpSession session = httpRequest.getSession(true);
         LoginResponse res = memberService.login(session, req);
 
         return new RspTemplate<>(HttpStatus.OK, "로그인에 성공하였습니다.", res);


### PR DESCRIPTION
## 🔎 작업 내용
- /api/searches에 익명 사용자 접근 허용 가능하도록 Filter 수정

## ➕ 이슈 링크
- #22 

## 📸 스크린샷(선택)

## 📝 체크리스트
- [x] 브랜치 이름은 `issue/이슈번호` 형식으로 작성했는가?
- [x] 커밋 메시지는 `[#이슈번호] Feat: 커밋 내용` 형식으로 작성했는가?
- [x] 코드에 주석은 최대한 없앴는가?
- [x] 코드 리뷰어의 피드백을 반영했는가?
- [ ] 테스트를 진행했는가?
- [ ] 테스트 코드를 작성했는가?
- [x] 불필요한 주석은 제거했는가?
