### PR TITLE
Feat: 검색목록 저장 및 조회기능 구현 / 인기검색어 저장 및 조회 기능 구현 예정

### DIFF
--- a/src/main/java/com/example/fourchelin/common/config/WebSecurityConfig.java
+++ b/src/main/java/com/example/fourchelin/common/config/WebSecurityConfig.java
@@ -21,13 +21,14 @@ public class WebSecurityConfig {
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+
         http.csrf((csrf) -> csrf.disable());
         http.sessionManagement((session) ->
                 session.sessionCreationPolicy(SessionCreationPolicy.IF_REQUIRED)
         );
 
         http.authorizeHttpRequests((authorization) ->
-                authorization.requestMatchers("/api/members/**").permitAll()
+                authorization.requestMatchers("/api/members/**", "/api/searches/**").permitAll()
                         .anyRequest().authenticated()
         );
 

--- a/src/main/java/com/example/fourchelin/common/filter/MemberAuthenticationFilter.java
+++ b/src/main/java/com/example/fourchelin/common/filter/MemberAuthenticationFilter.java
@@ -14,7 +14,6 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
-import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
@@ -26,17 +25,17 @@ public class MemberAuthenticationFilter extends OncePerRequestFilter {
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain chain) throws ServletException, IOException {
-
         String requestURI = request.getRequestURI();
         HttpSession session = request.getSession(false); // Session 정보를 가져오는데 없으면 세션을 새로 생성X
-
         if (session == null) {
-            throw new MemberException("requestURI : " + requestURI + "/인증되지 않은 사용자 입니다.");
+            if(requestURI.startsWith("/api/searches")){
+                chain.doFilter(request, response);
+            } else {
+                throw new MemberException("requestURI : " + requestURI + "/인증되지 않은 사용자 입니다.");
+            }
         }
-
         Member member = (Member) session.getAttribute("LOGIN_MEMBER");
         setAuthentication(member.getId());
-
         chain.doFilter(request, response);
     }
 
@@ -54,6 +53,8 @@ public class MemberAuthenticationFilter extends OncePerRequestFilter {
 
     @Override
     protected boolean shouldNotFilter(HttpServletRequest request) throws ServletException {
-        return StringUtils.startsWithIgnoreCase(request.getRequestURI(), "/api/members");
+        String requestURI = request.getRequestURI();
+        System.out.println("shouldNotFilter");
+        return requestURI.startsWith("/api/members");
     }
 }

--- a/src/main/java/com/example/fourchelin/domain/search/controller/SearchController.java
+++ b/src/main/java/com/example/fourchelin/domain/search/controller/SearchController.java
@@ -5,6 +5,7 @@ import com.example.fourchelin.common.template.RspTemplate;
 import com.example.fourchelin.domain.member.entity.Member;
 import com.example.fourchelin.domain.search.service.SearchService;
 import com.example.fourchelin.domain.store.dto.response.StorePageResponse;
+import com.example.fourchelin.domain.store.dto.response.StoreResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -13,12 +14,22 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.http.HttpStatus;
 
+import java.util.List;
+
 @RestController
 @RequestMapping("/api/searches")
 @RequiredArgsConstructor
 public class SearchController {
 
     private final SearchService searchService;
+
+    @GetMapping
+    public RspTemplate<List<String>> searchKeywordStore(@AuthenticationPrincipal UserDetailsImpl userDetails) {
+        // 인증된 유저일 경우 member 객체 가져오고 아니면 null
+        Member member = (userDetails != null) ? userDetails.getMember() : null;
+        List<String> res = searchService.searchKeywordStore(member);
+        return new RspTemplate<>(HttpStatus.OK, res);
+    }
 
     @GetMapping("/v1/stores")
     public RspTemplate<StorePageResponse> searchStore(@RequestParam String keyword,

--- a/src/main/java/com/example/fourchelin/domain/search/controller/SearchController.java
+++ b/src/main/java/com/example/fourchelin/domain/search/controller/SearchController.java
@@ -24,10 +24,10 @@ public class SearchController {
     private final SearchService searchService;
 
     @GetMapping
-    public RspTemplate<List<String>> searchKeywordStore(@AuthenticationPrincipal UserDetailsImpl userDetails) {
+    public RspTemplate<List<String>> searchKeyword(@AuthenticationPrincipal UserDetailsImpl userDetails) {
         // 인증된 유저일 경우 member 객체 가져오고 아니면 null
         Member member = (userDetails != null) ? userDetails.getMember() : null;
-        List<String> res = searchService.searchKeywordStore(member);
+        List<String> res = searchService.searchKeyword(member);
         return new RspTemplate<>(HttpStatus.OK, res);
     }
 

--- a/src/main/java/com/example/fourchelin/domain/search/controller/SearchController.java
+++ b/src/main/java/com/example/fourchelin/domain/search/controller/SearchController.java
@@ -1,9 +1,12 @@
 package com.example.fourchelin.domain.search.controller;
 
+import com.example.fourchelin.common.security.UserDetailsImpl;
 import com.example.fourchelin.common.template.RspTemplate;
+import com.example.fourchelin.domain.member.entity.Member;
 import com.example.fourchelin.domain.search.service.SearchService;
 import com.example.fourchelin.domain.store.dto.response.StorePageResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -20,9 +23,11 @@ public class SearchController {
     @GetMapping("/v1/stores")
     public RspTemplate<StorePageResponse> searchStore(@RequestParam String keyword,
                                                       @RequestParam(defaultValue = "1") int page,
-                                                      @RequestParam(defaultValue = "10") int size) {
-        StorePageResponse res = searchService.searchStore(keyword, page, size);
+                                                      @RequestParam(defaultValue = "10") int size,
+                                                      @AuthenticationPrincipal UserDetailsImpl userDetails) {
+        // 인증된 유저일 경우 member 객체 가져오고 아니면 null
+        Member member = (userDetails != null) ? userDetails.getMember() : null;
+        StorePageResponse res = searchService.searchStore(keyword, page, size, member);
         return new RspTemplate<>(HttpStatus.OK, res);
-
     }
 }

--- a/src/main/java/com/example/fourchelin/domain/search/entity/SearchHistory.java
+++ b/src/main/java/com/example/fourchelin/domain/search/entity/SearchHistory.java
@@ -26,8 +26,12 @@ public class SearchHistory{
     private Member member;
 
     @Builder
-    public SearchHistory(String keyword, LocalDateTime searchDateTime) {
+    public SearchHistory(String keyword, LocalDateTime searchDateTime, Member member) {
         this.keyword = keyword;
+        this.searchDateTime = searchDateTime;
+        this.member = member;
+    }
+    public void updateSearchDateTime(LocalDateTime searchDateTime) {
         this.searchDateTime = searchDateTime;
     }
 }

--- a/src/main/java/com/example/fourchelin/domain/search/entity/SearchHistory.java
+++ b/src/main/java/com/example/fourchelin/domain/search/entity/SearchHistory.java
@@ -31,8 +31,8 @@ public class SearchHistory{
         this.searchDateTime = searchDateTime;
         this.member = member;
     }
-    public void updateSearchDateTime(LocalDateTime searchDateTime) {
-        this.searchDateTime = searchDateTime;
+    public void updateSearchDateTime(LocalDateTime newSearchDateTime) {
+        this.searchDateTime = newSearchDateTime;
     }
     // 검색기록 추가 Test 관련 출력값을 보기 위해 작성
     @Override

--- a/src/main/java/com/example/fourchelin/domain/search/entity/SearchHistory.java
+++ b/src/main/java/com/example/fourchelin/domain/search/entity/SearchHistory.java
@@ -34,4 +34,14 @@ public class SearchHistory{
     public void updateSearchDateTime(LocalDateTime searchDateTime) {
         this.searchDateTime = searchDateTime;
     }
+    // 검색기록 추가 Test 관련 출력값을 보기 위해 작성
+    @Override
+    public String toString() {
+        return "SearchHistory{" +
+                "id=" + id +
+                ", keyword='" + keyword + '\'' +
+                ", member='" + (member != null ? member.getNickname() : "null") + '\'' +
+                ", searchDateTime=" + searchDateTime +
+                '}';
+    }
 }

--- a/src/main/java/com/example/fourchelin/domain/search/entity/SearchHistory.java
+++ b/src/main/java/com/example/fourchelin/domain/search/entity/SearchHistory.java
@@ -1,7 +1,9 @@
 package com.example.fourchelin.domain.search.entity;
 
+import com.example.fourchelin.domain.member.entity.Member;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -19,7 +21,13 @@ public class SearchHistory{
     @Column(nullable = false)
     private LocalDateTime searchDateTime;
 
-    /*@ManyToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
-    private Member member;*/
+    private Member member;
+
+    @Builder
+    public SearchHistory(String keyword, LocalDateTime searchDateTime) {
+        this.keyword = keyword;
+        this.searchDateTime = searchDateTime;
+    }
 }

--- a/src/main/java/com/example/fourchelin/domain/search/repository/SearchHistoryRepository.java
+++ b/src/main/java/com/example/fourchelin/domain/search/repository/SearchHistoryRepository.java
@@ -1,7 +1,9 @@
 package com.example.fourchelin.domain.search.repository;
 
 import com.example.fourchelin.domain.search.entity.SearchHistory;
+import com.example.fourchelin.domain.search.repository.support.SearchHistoryRepositoryCustom;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface SearchHistoryRepository extends JpaRepository<SearchHistory, Long> {
+public interface SearchHistoryRepository extends JpaRepository<SearchHistory, Long>, SearchHistoryRepositoryCustom {
+
 }

--- a/src/main/java/com/example/fourchelin/domain/search/repository/SearchHistoryRepository.java
+++ b/src/main/java/com/example/fourchelin/domain/search/repository/SearchHistoryRepository.java
@@ -1,0 +1,7 @@
+package com.example.fourchelin.domain.search.repository;
+
+import com.example.fourchelin.domain.search.entity.SearchHistory;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SearchHistoryRepository extends JpaRepository<SearchHistory, Long> {
+}

--- a/src/main/java/com/example/fourchelin/domain/search/repository/support/SearchHistoryRepositoryCustom.java
+++ b/src/main/java/com/example/fourchelin/domain/search/repository/support/SearchHistoryRepositoryCustom.java
@@ -3,6 +3,9 @@ package com.example.fourchelin.domain.search.repository.support;
 import com.example.fourchelin.domain.member.entity.Member;
 import com.example.fourchelin.domain.search.entity.SearchHistory;
 
+import java.util.List;
+
 public interface SearchHistoryRepositoryCustom {
     SearchHistory findByKeywordAndMember(String keyword, Member member);
+    List<SearchHistory> keywordFindByMember(Member member);
 }

--- a/src/main/java/com/example/fourchelin/domain/search/repository/support/SearchHistoryRepositoryCustom.java
+++ b/src/main/java/com/example/fourchelin/domain/search/repository/support/SearchHistoryRepositoryCustom.java
@@ -1,0 +1,8 @@
+package com.example.fourchelin.domain.search.repository.support;
+
+import com.example.fourchelin.domain.member.entity.Member;
+import com.example.fourchelin.domain.search.entity.SearchHistory;
+
+public interface SearchHistoryRepositoryCustom {
+    SearchHistory findByKeywordAndMember(String keyword, Member member);
+}

--- a/src/main/java/com/example/fourchelin/domain/search/repository/support/SearchHistoryRepositoryCustomImpl.java
+++ b/src/main/java/com/example/fourchelin/domain/search/repository/support/SearchHistoryRepositoryCustomImpl.java
@@ -1,0 +1,27 @@
+package com.example.fourchelin.domain.search.repository.support;
+
+import com.example.fourchelin.domain.member.entity.Member;
+import com.example.fourchelin.domain.search.entity.QSearchHistory;
+import com.example.fourchelin.domain.search.entity.SearchHistory;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class SearchHistoryRepositoryCustomImpl implements SearchHistoryRepositoryCustom {
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    @Override
+    public SearchHistory findByKeywordAndMember(String keyword, Member member) {
+        QSearchHistory searchHistory = QSearchHistory.searchHistory;
+
+        return jpaQueryFactory
+                .selectFrom(searchHistory)
+                .where(searchHistory.keyword.eq(keyword)
+                        .and(searchHistory.member.eq(member))
+                )
+                .fetchOne();
+    }
+}

--- a/src/main/java/com/example/fourchelin/domain/search/repository/support/SearchHistoryRepositoryCustomImpl.java
+++ b/src/main/java/com/example/fourchelin/domain/search/repository/support/SearchHistoryRepositoryCustomImpl.java
@@ -7,21 +7,31 @@ import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
+import java.util.List;
+
 @Component
 @RequiredArgsConstructor
 public class SearchHistoryRepositoryCustomImpl implements SearchHistoryRepositoryCustom {
 
     private final JPAQueryFactory jpaQueryFactory;
+    private final QSearchHistory searchHistory = QSearchHistory.searchHistory;
 
     @Override
     public SearchHistory findByKeywordAndMember(String keyword, Member member) {
-        QSearchHistory searchHistory = QSearchHistory.searchHistory;
-
         return jpaQueryFactory
                 .selectFrom(searchHistory)
                 .where(searchHistory.keyword.eq(keyword)
                         .and(searchHistory.member.eq(member))
                 )
                 .fetchOne();
+    }
+    @Override
+    public List<SearchHistory> keywordFindByMember(Member member) {
+        return jpaQueryFactory
+                .selectFrom(searchHistory)
+                .where(searchHistory.member.eq(member))
+                .orderBy(searchHistory.searchDateTime.desc())
+                .limit(10)
+                .fetch();
     }
 }

--- a/src/main/java/com/example/fourchelin/domain/search/service/SearchService.java
+++ b/src/main/java/com/example/fourchelin/domain/search/service/SearchService.java
@@ -4,7 +4,6 @@ import com.example.fourchelin.domain.member.entity.Member;
 import com.example.fourchelin.domain.search.entity.SearchHistory;
 import com.example.fourchelin.domain.search.repository.SearchHistoryRepository;
 import com.example.fourchelin.domain.store.dto.response.StorePageResponse;
-import com.example.fourchelin.domain.store.dto.response.StoreResponse;
 import com.example.fourchelin.domain.store.entity.Store;
 import com.example.fourchelin.domain.store.exception.StoreException;
 import com.example.fourchelin.domain.store.repository.StoreRepository;
@@ -30,19 +29,17 @@ public class SearchService {
         }
 
         // 인증된 사용자인 경우에만 검색기록 저장
-        if(member != null) {
+        if (member != null) {
             saveOrUpdateSearchHistory(keyword, member);
         }
-
         Pageable pageable = PageRequest.of(page - 1, size);
         Page<Store> stores = storeRepository.findByKeyword(keyword, pageable);
-
         return new StorePageResponse(stores);
     }
 
     public List<String> searchKeywordStore(Member member) {
         // 인증 유저가 아닌 경우
-        if(member == null) {
+        if (member == null) {
             return List.of();
         }
         List<SearchHistory> searchHistories = searchHistoryRepository.keywordFindByMember(member);
@@ -60,7 +57,6 @@ public class SearchService {
         SearchHistory existKeyword = searchHistoryRepository.findByKeywordAndMember(keyword, member);
         if (existKeyword != null) {
             existKeyword.updateSearchDateTime(LocalDateTime.now());
-            searchHistoryRepository.save(existKeyword);
         } else {
             SearchHistory searchHistory = SearchHistory.builder()
                     .keyword(keyword)

--- a/src/main/java/com/example/fourchelin/domain/search/service/SearchService.java
+++ b/src/main/java/com/example/fourchelin/domain/search/service/SearchService.java
@@ -7,7 +7,6 @@ import com.example.fourchelin.domain.store.dto.response.StorePageResponse;
 import com.example.fourchelin.domain.store.entity.Store;
 import com.example.fourchelin.domain.store.exception.StoreException;
 import com.example.fourchelin.domain.store.repository.StoreRepository;
-import jakarta.persistence.EntityManager;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;

--- a/src/main/java/com/example/fourchelin/domain/search/service/SearchService.java
+++ b/src/main/java/com/example/fourchelin/domain/search/service/SearchService.java
@@ -4,6 +4,7 @@ import com.example.fourchelin.domain.member.entity.Member;
 import com.example.fourchelin.domain.search.entity.SearchHistory;
 import com.example.fourchelin.domain.search.repository.SearchHistoryRepository;
 import com.example.fourchelin.domain.store.dto.response.StorePageResponse;
+import com.example.fourchelin.domain.store.dto.response.StoreResponse;
 import com.example.fourchelin.domain.store.entity.Store;
 import com.example.fourchelin.domain.store.exception.StoreException;
 import com.example.fourchelin.domain.store.repository.StoreRepository;
@@ -14,6 +15,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -36,6 +38,21 @@ public class SearchService {
         Page<Store> stores = storeRepository.findByKeyword(keyword, pageable);
 
         return new StorePageResponse(stores);
+    }
+
+    public List<String> searchKeywordStore(Member member) {
+        // 인증 유저가 아닌 경우
+        if(member == null) {
+            return List.of();
+        }
+        List<SearchHistory> searchHistories = searchHistoryRepository.keywordFindByMember(member);
+        // 검색 결과가 없는 경우
+        if (searchHistories.isEmpty()) {
+            return List.of();
+        }
+        return searchHistories.stream()
+                .map(SearchHistory::getKeyword)
+                .toList();
     }
 
     private void saveOrUpdateSearchHistory(String keyword, Member member) {

--- a/src/main/java/com/example/fourchelin/domain/search/service/SearchService.java
+++ b/src/main/java/com/example/fourchelin/domain/search/service/SearchService.java
@@ -7,11 +7,13 @@ import com.example.fourchelin.domain.store.dto.response.StorePageResponse;
 import com.example.fourchelin.domain.store.entity.Store;
 import com.example.fourchelin.domain.store.exception.StoreException;
 import com.example.fourchelin.domain.store.repository.StoreRepository;
+import jakarta.persistence.EntityManager;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -23,6 +25,7 @@ public class SearchService {
     private final StoreRepository storeRepository;
     private final SearchHistoryRepository searchHistoryRepository;
 
+    @Transactional
     public StorePageResponse searchStore(String keyword, int page, int size, Member member) {
         if (keyword == null || keyword.trim().isEmpty()) {
             throw new StoreException("검색어를 입력해주세요");
@@ -57,6 +60,7 @@ public class SearchService {
         SearchHistory existKeyword = searchHistoryRepository.findByKeywordAndMember(keyword, member);
         if (existKeyword != null) {
             existKeyword.updateSearchDateTime(LocalDateTime.now());
+            searchHistoryRepository.save(existKeyword);
         } else {
             SearchHistory searchHistory = SearchHistory.builder()
                     .keyword(keyword)

--- a/src/main/java/com/example/fourchelin/domain/search/service/SearchService.java
+++ b/src/main/java/com/example/fourchelin/domain/search/service/SearchService.java
@@ -1,5 +1,7 @@
 package com.example.fourchelin.domain.search.service;
 
+import com.example.fourchelin.domain.search.entity.SearchHistory;
+import com.example.fourchelin.domain.search.repository.SearchHistoryRepository;
 import com.example.fourchelin.domain.store.dto.response.StorePageResponse;
 import com.example.fourchelin.domain.store.entity.Store;
 import com.example.fourchelin.domain.store.exception.StoreException;
@@ -10,21 +12,33 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDateTime;
+
 @Service
 @RequiredArgsConstructor
 public class SearchService {
 
     private final StoreRepository storeRepository;
+    private final SearchHistoryRepository searchHistoryRepository;
 
     public StorePageResponse searchStore(String keyword, int page, int size) {
         if (keyword == null || keyword.trim().isEmpty()) {
             throw new StoreException("검색어를 입력해주세요");
         }
 
+        saveSearchHistory(keyword);
+
         Pageable pageable = PageRequest.of(page - 1, size);
         Page<Store> stores = storeRepository.findByKeyword(keyword, pageable);
 
         return new StorePageResponse(stores);
-
+    }
+    
+    private void saveSearchHistory(String keyword) {
+        SearchHistory searchHistory = SearchHistory.builder()
+                .keyword(keyword)
+                .searchDateTime(LocalDateTime.now())
+                .build();
+        searchHistoryRepository.save(searchHistory);
     }
 }

--- a/src/main/java/com/example/fourchelin/domain/search/service/SearchService.java
+++ b/src/main/java/com/example/fourchelin/domain/search/service/SearchService.java
@@ -37,7 +37,7 @@ public class SearchService {
         return new StorePageResponse(stores);
     }
 
-    public List<String> searchKeywordStore(Member member) {
+    public List<String> searchKeyword(Member member) {
         // 인증 유저가 아닌 경우
         if (member == null) {
             return List.of();

--- a/src/main/java/com/example/fourchelin/domain/store/entity/Store.java
+++ b/src/main/java/com/example/fourchelin/domain/store/entity/Store.java
@@ -32,7 +32,7 @@ public class Store extends Timestamped {
     private String address;
 
     @Column
-    private Integer star;
+    private int star;
 
     public Store(Long id, String storeName, String address) {
         this.id = id;

--- a/src/test/java/com/example/fourchelin/search/service/SearchServiceTest.java
+++ b/src/test/java/com/example/fourchelin/search/service/SearchServiceTest.java
@@ -215,7 +215,7 @@ class SearchServiceTest {
         when(searchHistoryRepository.keywordFindByMember(any(Member.class))).thenReturn(limitedSearchHistories);
 
 
-        List<String> keywords = searchService.searchKeywordStore(member);
+        List<String> keywords = searchService.searchKeyword(member);
 
         System.out.println("검색어 목록: " + keywords);
 
@@ -234,7 +234,7 @@ class SearchServiceTest {
 
         when(searchHistoryRepository.keywordFindByMember(any())).thenReturn(Collections.emptyList());
 
-        List<String> keywords = searchService.searchKeywordStore(member);
+        List<String> keywords = searchService.searchKeyword(member);
 
         System.out.println("검색어 목록: " + keywords);
 

--- a/src/test/java/com/example/fourchelin/search/service/SearchServiceTest.java
+++ b/src/test/java/com/example/fourchelin/search/service/SearchServiceTest.java
@@ -1,5 +1,9 @@
 package com.example.fourchelin.search.service;
 
+import com.example.fourchelin.domain.member.entity.Member;
+import com.example.fourchelin.domain.member.enums.MemberRole;
+import com.example.fourchelin.domain.search.entity.SearchHistory;
+import com.example.fourchelin.domain.search.repository.SearchHistoryRepository;
 import com.example.fourchelin.domain.search.service.SearchService;
 import com.example.fourchelin.domain.store.dto.response.StorePageResponse;
 import com.example.fourchelin.domain.store.entity.Store;
@@ -7,25 +11,30 @@ import com.example.fourchelin.domain.store.exception.StoreException;
 import com.example.fourchelin.domain.store.repository.StoreRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 class SearchServiceTest {
 
     @Mock
     private StoreRepository storeRepository;
+    @Mock
+    private SearchHistoryRepository searchHistoryRepository;
 
     @InjectMocks
     private SearchService searchService;
@@ -48,6 +57,8 @@ class SearchServiceTest {
         Store store3 = new Store(3L, "레스토랑", "서울시 서초구");
         List<Store> allStores = List.of(store1, store2, store3);
 
+        Member member = new Member("01012345678", "user1", "password", MemberRole.USER);
+
         // 가게 목록을 키워드에 따라 필터링하여 반환하도록 설정
         when(storeRepository.findByKeyword(eq(keyword), any(Pageable.class)))
                 .thenAnswer(invocation -> {
@@ -58,7 +69,7 @@ class SearchServiceTest {
                     return new PageImpl<>(filteredStores, pageable, filteredStores.size());
                 });
 
-        StorePageResponse response = searchService.searchStore(keyword, page, size);
+        StorePageResponse response = searchService.searchStore(keyword, page, size, member);
 
         assertThat(response).isNotNull();
         assertThat(response.getStoreResponses()).hasSize(2);
@@ -77,6 +88,8 @@ class SearchServiceTest {
         Store store3 = new Store(3L, "레스토랑", "서울시 서초구");
         List<Store> allStores = List.of(store1, store2, store3);
 
+        Member member = new Member("01012345678", "user1", "password", MemberRole.USER);
+
         // 가게 목록을 키워드에 따라 필터링하여 반환하도록 설정
         when(storeRepository.findByKeyword(eq(keyword), any(Pageable.class)))
                 .thenAnswer(invocation -> {
@@ -87,12 +100,11 @@ class SearchServiceTest {
                     return new PageImpl<>(filteredStores, pageable, filteredStores.size());
                 });
 
-        StorePageResponse response = searchService.searchStore(keyword, page, size);
+        StorePageResponse response = searchService.searchStore(keyword, page, size, member);
 
         assertThat(response).isNotNull();
         assertThat(response.getStoreResponses()).isEmpty();
         assertThat(response.getTotalElements()).isEqualTo(0);
-
     }
 
     @Test
@@ -100,10 +112,84 @@ class SearchServiceTest {
         String keyword = "";
         int page = 1;
         int size = 10;
+        Member member = new Member("01012345678", "user1", "password", MemberRole.USER);
 
-        assertThatThrownBy(() -> searchService.searchStore(keyword, page, size))
+        assertThatThrownBy(() -> searchService.searchStore(keyword, page, size, member))
                 .isInstanceOf(StoreException.class)
                 .hasMessage("검색어를 입력해주세요");
     }
+
+    // [검색기록 테스트]===========================================================================================
+
+    @Test
+    void searchStore_Success_SaveKeword() {
+
+        String keyword = "카페";
+        int page = 1;
+        int size = 10;
+        Member member = new Member("01012345678", "user1", "password", MemberRole.USER);
+        Pageable pageable = PageRequest.of(page - 1, size);
+        Page<Store> storePage = new PageImpl<>(List.of(), pageable, 0);
+
+        when(storeRepository.findByKeyword(eq(keyword), any(Pageable.class))).thenReturn(storePage);
+        when(searchHistoryRepository.findByKeywordAndMember(eq(keyword), eq(member))).thenReturn(null);
+
+        doAnswer(invocation -> {
+            SearchHistory savedHistory = invocation.getArgument(0);
+            System.out.println("Saved SearchHistory: " + savedHistory);
+            return null;
+        }).when(searchHistoryRepository).save(any(SearchHistory.class));
+
+        StorePageResponse response = searchService.searchStore(keyword, page, size, member);
+
+        verify(searchHistoryRepository, times(1)).save(any(SearchHistory.class));
+        assertThat(response).isNotNull();
+    }
+
+    @Test
+    void searchStore_Success_UpdateSearchDateTime() {
+        String keyword = "카페";
+        int page = 1;
+        int size = 10;
+        Pageable pageable = PageRequest.of(page - 1, size);
+
+        // 기존의 검색 기록이 존재하는 상태 설정
+        Member member = new Member("01012345678", "user1", "password", MemberRole.USER);
+        SearchHistory existingHistory = SearchHistory.builder()
+                .keyword(keyword)
+                .member(member)
+                .searchDateTime(LocalDateTime.now().minusDays(1)) // 하루 전 검색 기록
+                .build();
+
+        when(searchHistoryRepository.findByKeywordAndMember(eq(keyword), eq(member)))
+                .thenReturn(existingHistory);
+
+        Store store1 = new Store(1L, "아카페라", "서울시 강남구");
+        Store store2 = new Store(2L, "카페라떼는말이야", "서울시 종로구");
+        List<Store> allStores = List.of(store1, store2);
+
+        // 가게 목록을 키워드에 따라 필터링하여 반환하도록 설정
+        when(storeRepository.findByKeyword(eq(keyword), any(Pageable.class)))
+                .thenAnswer(invocation -> {
+                    List<Store> filteredStores = allStores.stream()
+                            .filter(store -> store.getStoreName().contains(keyword))
+                            .toList();
+                    return new PageImpl<>(filteredStores, pageable, filteredStores.size());
+                });
+
+        System.out.println("Before search: searchDateTime = " + existingHistory.getSearchDateTime());
+        StorePageResponse response = searchService.searchStore(keyword, page, size, member);
+        System.out.println("After search: searchDateTime = " + existingHistory.getSearchDateTime());
+
+        assertThat(response).isNotNull();
+        assertThat(response.getStoreResponses()).hasSize(2);
+        assertThat(response.getTotalElements()).isEqualTo(2);
+
+        verify(searchHistoryRepository, times(1)).save(existingHistory);
+        assertThat(existingHistory.getSearchDateTime()).isAfter(LocalDateTime.now().minusMinutes(1));
+    }
+
+// []===========================================================================================
+
 
 }

--- a/src/test/java/com/example/fourchelin/search/service/SearchServiceTest.java
+++ b/src/test/java/com/example/fourchelin/search/service/SearchServiceTest.java
@@ -11,7 +11,6 @@ import com.example.fourchelin.domain.store.exception.StoreException;
 import com.example.fourchelin.domain.store.repository.StoreRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
@@ -21,6 +20,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 
 import java.time.LocalDateTime;
+import java.util.Collections;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -189,7 +189,58 @@ class SearchServiceTest {
         assertThat(existingHistory.getSearchDateTime()).isAfter(LocalDateTime.now().minusMinutes(1));
     }
 
-// []===========================================================================================
+    // [검색기록 조회 테스트]===========================================================================================
+
+    @Test
+    void searchKeyword_Success() {
+
+        Member member = new Member("01012345678", "user1", "password", MemberRole.USER);
+
+        List<SearchHistory> searchHistories = List.of(
+                SearchHistory.builder().keyword("검색어1").member(member).searchDateTime(LocalDateTime.now().minusMinutes(1)).build(),
+                SearchHistory.builder().keyword("검색어2").member(member).searchDateTime(LocalDateTime.now().minusMinutes(2)).build(),
+                SearchHistory.builder().keyword("검색어3").member(member).searchDateTime(LocalDateTime.now().minusMinutes(3)).build(),
+                SearchHistory.builder().keyword("검색어4").member(member).searchDateTime(LocalDateTime.now().minusMinutes(4)).build(),
+                SearchHistory.builder().keyword("검색어5").member(member).searchDateTime(LocalDateTime.now().minusMinutes(5)).build(),
+                SearchHistory.builder().keyword("검색어6").member(member).searchDateTime(LocalDateTime.now().minusMinutes(6)).build(),
+                SearchHistory.builder().keyword("검색어7").member(member).searchDateTime(LocalDateTime.now().minusMinutes(7)).build(),
+                SearchHistory.builder().keyword("검색어8").member(member).searchDateTime(LocalDateTime.now().minusMinutes(8)).build(),
+                SearchHistory.builder().keyword("검색어9").member(member).searchDateTime(LocalDateTime.now().minusMinutes(9)).build(),
+                SearchHistory.builder().keyword("검색어10").member(member).searchDateTime(LocalDateTime.now().minusMinutes(10)).build(),
+                SearchHistory.builder().keyword("검색어11").member(member).searchDateTime(LocalDateTime.now().minusMinutes(11)).build(),
+                SearchHistory.builder().keyword("검색어12").member(member).searchDateTime(LocalDateTime.now().minusMinutes(12)).build()
+        );
+
+        List<SearchHistory> limitedSearchHistories = searchHistories.subList(0, 10);
+        when(searchHistoryRepository.keywordFindByMember(any(Member.class))).thenReturn(limitedSearchHistories);
 
 
+        List<String> keywords = searchService.searchKeywordStore(member);
+
+        System.out.println("검색어 목록: " + keywords);
+
+        assertThat(keywords).isNotNull();
+        assertThat(keywords).hasSize(10);
+        assertThat(keywords).containsExactly(
+                "검색어1", "검색어2", "검색어3", "검색어4", "검색어5",
+                "검색어6", "검색어7", "검색어8", "검색어9", "검색어10"
+        );
+    }
+
+    @Test
+    void searchKeyword_Success_NotMember() {
+        // 인증되지 않은 사용자
+        Member member = null;
+
+        when(searchHistoryRepository.keywordFindByMember(any())).thenReturn(Collections.emptyList());
+
+        List<String> keywords = searchService.searchKeywordStore(member);
+
+        System.out.println("검색어 목록: " + keywords);
+
+        assertThat(keywords).isNotNull();
+        assertThat(keywords).isEmpty();
+    }
+
+    // []===========================================================================================
 }


### PR DESCRIPTION
## 🔎 작업 내용
- 검색목록 저장 (인증된 유저에 한하여)
- 검색목록 조회 (인증된 유저에 한하여 본인 검색기록 조회)
- 단위 테스트
  - 검색목록 저장 성공 테스트 (기록 없는 경우 저장, 기록 있는 경우 검색일자 업데이트)
  - 검색목록 조회 성공 테스트 (인증된 유저인경우, 인증된 유저가 아닌 경우)

## ➕ 이슈 링크
- #15 

## 📸 스크린샷(선택)


## 📝 체크리스트
- [x] 브랜치 이름은 `issue/이슈번호` 형식으로 작성했는가?
- [x] 커밋 메시지는 `[#이슈번호] Feat: 커밋 내용` 형식으로 작성했는가?
- [ ] 코드에 주석은 최대한 없앴는가?
- [ ] 코드 리뷰어의 피드백을 반영했는가?
- [x] 테스트를 진행했는가?
- [x] 테스트 코드를 작성했는가?
- [x] 불필요한 주석은 제거했는가?
