### PR TITLE
Feat: In-memory Cache를 적용한 v2 인기검색어 저장 구현 / In-memory Cache를 적용한 v2 인기검색어 조회 구현 예정

### DIFF
--- a/src/main/java/com/example/fourchelin/domain/search/controller/SearchController.java
+++ b/src/main/java/com/example/fourchelin/domain/search/controller/SearchController.java
@@ -42,4 +42,15 @@ public class SearchController {
         StorePageResponse res = searchService.searchStore(keyword, page, size, member);
         return new RspTemplate<>(HttpStatus.OK, res);
     }
+
+    @GetMapping("/v2/stores")
+    public RspTemplate<StorePageResponse> searchStoreV2(@RequestParam String keyword,
+                                                      @RequestParam(defaultValue = "1") int page,
+                                                      @RequestParam(defaultValue = "10") int size,
+                                                      @AuthenticationPrincipal UserDetailsImpl userDetails) {
+        // 인증된 유저일 경우 member 객체 가져오고 아니면 null
+        Member member = (userDetails != null) ? userDetails.getMember() : null;
+        StorePageResponse res = searchService.searchStoreV2(keyword, page, size, member);
+        return new RspTemplate<>(HttpStatus.OK, res);
+    }
 }

--- a/src/main/java/com/example/fourchelin/domain/search/entity/PopularKeywordCache.java
+++ b/src/main/java/com/example/fourchelin/domain/search/entity/PopularKeywordCache.java
@@ -1,0 +1,26 @@
+package com.example.fourchelin.domain.search.entity;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PopularKeywordCache {
+
+    private String keyword;
+    private LocalDate date;
+    private Long count;
+
+    public PopularKeywordCache(String keyword, LocalDate date, Long count) {
+        this.keyword = keyword;
+        this.date = date;
+        this.count = count;
+    }
+
+    public void incrementCount() {
+        this.count++;
+    }
+}

--- a/src/main/java/com/example/fourchelin/domain/search/service/SearchService.java
+++ b/src/main/java/com/example/fourchelin/domain/search/service/SearchService.java
@@ -2,6 +2,7 @@ package com.example.fourchelin.domain.search.service;
 
 import com.example.fourchelin.domain.member.entity.Member;
 import com.example.fourchelin.domain.search.entity.PopularKeyword;
+import com.example.fourchelin.domain.search.entity.PopularKeywordCache;
 import com.example.fourchelin.domain.search.entity.SearchHistory;
 import com.example.fourchelin.domain.search.repository.PopularKeywordRepository;
 import com.example.fourchelin.domain.search.repository.SearchHistoryRepository;
@@ -22,6 +23,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
 
 @Service
 @RequiredArgsConstructor
@@ -30,25 +32,38 @@ public class SearchService {
     private final StoreRepository storeRepository;
     private final SearchHistoryRepository searchHistoryRepository;
     private final PopularKeywordRepository popularKeywordRepository;
+    private final Map<String, PopularKeywordCache> popularKeywordCache = new ConcurrentHashMap<>();
 
     @Transactional
     public StorePageResponse searchStore(String keyword, int page, int size, Member member) {
-        if (keyword == null || keyword.trim().isEmpty()) {
-            throw new StoreException("검색어를 입력해주세요");
-        }
-        // 인증된 사용자인 경우에만 검색기록 저장
-        if (member != null) {
-            saveOrUpdateSearchHistory(keyword, member);
-        }
+        searchKeywordAndUpdateSearchHistory(keyword, member);
         saveOrUpdatePopularKeyword(keyword);
         Pageable pageable = PageRequest.of(page - 1, size);
         Page<Store> stores = storeRepository.findByKeyword(keyword, pageable);
         return new StorePageResponse(stores);
     }
 
+    // In-memory Cache
+    @Transactional
+    public StorePageResponse searchStoreV2(String keyword, int page, int size, Member member) {
+        searchKeywordAndUpdateSearchHistory(keyword, member);
+        updateKeywordCount(keyword);
+        Pageable pageable = PageRequest.of(page - 1, size);
+        Page<Store> stores = storeRepository.findByKeyword(keyword, pageable);
+        return new StorePageResponse(stores);
+    }
+
+    public void searchKeywordAndUpdateSearchHistory(String keyword, Member member) {
+        if (keyword == null || keyword.trim().isEmpty()) {
+            throw new StoreException("검색어를 입력해주세요");
+        }
+        if (member != null) {
+            saveOrUpdateSearchHistory(keyword, member);
+        }
+    }
+
     public Map<String, List<String>> searchKeyword(Member member) {
         Map<String, List<String>> result = new HashMap<>();
-        // 사용자 검색 기록 조회
         if (member != null) {
             List<SearchHistory> searchHistories = searchHistoryRepository.keywordFindByMember(member);
             List<String> searchKeywords = searchHistories.stream()
@@ -85,14 +100,32 @@ public class SearchService {
         Optional<PopularKeyword> optionalPopularKeyword = popularKeywordRepository.findByKeywordAndTrendDate(keyword, today);
 
         if (optionalPopularKeyword.isPresent()) {
-            // 기존 키워드가 있는 경우 카운트를 증가시킴
             PopularKeyword popularKeyword = optionalPopularKeyword.get();
             popularKeyword.incrementCount();
             popularKeywordRepository.save(popularKeyword);
         } else {
-            // 키워드가 없는 경우 새로 생성하고 카운트를 1로 설정
             PopularKeyword newPopularKeyword = new PopularKeyword(keyword, today);
             popularKeywordRepository.save(newPopularKeyword);
         }
+    }
+
+    public void updateKeywordCount(String keyword) {
+        LocalDate today = LocalDate.now();
+        String cacheKey = createCacheKey(keyword, today);
+        PopularKeywordCache keywordCache = popularKeywordCache.get(cacheKey);
+        if (keywordCache != null) {
+            keywordCache.incrementCount();
+        } else {
+            popularKeywordCache.put(cacheKey, new PopularKeywordCache(keyword, today, 1L));
+        }
+    }
+
+    private String createCacheKey(String keyword, LocalDate date) {
+        return keyword + "_" + date.toString();
+    }
+
+    // 테스트 결과 출력을 위한 코드
+    public Map<String, PopularKeywordCache> getPopularKeywordCache() {
+        return popularKeywordCache;
     }
 }


### PR DESCRIPTION
## 🔎 작업 내용
- In-memory Cache를 적용한 v2 인기검색어 저장 기능 추가
- In-memory Cache를 적용한 v2 인기검색어 저장 테스트

## ➕ 이슈 링크
- #27

## 📸 스크린샷(선택)

## 📝 체크리스트
- [x] 브랜치 이름은 `issue/이슈번호` 형식으로 작성했는가?
- [x] 커밋 메시지는 `[#이슈번호] Feat: 커밋 내용` 형식으로 작성했는가?
- [x] 불필요한 주석은 제거했는가?
- [ ] 코드 리뷰어의 피드백을 반영했는가?
- [x] 테스트를 진행했는가?
- [x] 테스트 코드를 작성했는가?