### PR TITLE
Refactor: 캐시에 저장되는 데이터 형식 변경 / In-memory Cache를 적용한 v2 인기검색어 조회 구현 예정

### DIFF
--- a/src/main/java/com/example/fourchelin/domain/search/service/KeywordCacheService.java
+++ b/src/main/java/com/example/fourchelin/domain/search/service/KeywordCacheService.java
@@ -20,20 +20,19 @@ public class KeywordCacheService {
     private final PopularKeywordRepository popularKeywordRepository;
 
     @Transactional(propagation = Propagation.REQUIRES_NEW)
-    @CachePut(value = "keywordCount", key = "#keyword + '_' + #today.toString()")
+    @CachePut(value = "keywordCounts", key = "#keyword")
     public Long saveOrUpdateKeywordCountWithCache(String keyword, LocalDate today) {
         Cache cache = cacheManager.getCache("keywordCount");
-        String cacheKey = keyword + "_" + today.toString();
         Long newCount = 1L;
 
         if (cache != null) {
-            Long currentCount = cache.get(cacheKey, Long.class);
+            Long currentCount = cache.get(keyword, Long.class);
             if (currentCount != null) {
                 newCount = currentCount + 1;
             }
         }
 
-        cache.put(cacheKey, newCount);
+        cache.put(keyword, newCount);
         return newCount;
     }
 }

--- a/src/main/java/com/example/fourchelin/domain/search/service/SearchService.java
+++ b/src/main/java/com/example/fourchelin/domain/search/service/SearchService.java
@@ -48,7 +48,7 @@ public class SearchService {
         searchKeywordAndUpdateSearchHistory(keyword, member);
         keywordCacheService.saveOrUpdateKeywordCountWithCache(keyword, LocalDate.now());
         // 캐시 저장 확인
-        cacheService.displayCache("keywordCount");
+        cacheService.displayCache("keywordCounts");
         Pageable pageable = PageRequest.of(page - 1, size);
         Page<Store> stores = storeRepository.findByKeyword(keyword, pageable);
         return new StorePageResponse(stores);


### PR DESCRIPTION
## 🔎 작업 내용
- 캐시에 저장되는 내용 변경
기존 : key = keyword_date , value = count
변경 : key = keyword, value = count

## ➕ 이슈 링크
- #40 

## 📸 스크린샷(선택)
![image](https://github.com/user-attachments/assets/c76269f2-155e-45ed-a2b3-409ac311fd29)

## 📝 체크리스트
- [x] 브랜치 이름은 `issue/이슈번호` 형식으로 작성했는가?
- [x] 커밋 메시지는 `[#이슈번호] Feat: 커밋 내용` 형식으로 작성했는가?
- [x] 불필요한 주석은 제거했는가?
- [ ] 코드 리뷰어의 피드백을 반영했는가?
- [ ] 테스트를 진행했는가?
- [ ] 테스트 코드를 작성했는가?