### PR TITLE
Feat: In-memory Cache를 적용한 v2 인기검색어 조회 구현 / Redis를 이용한 인기검색어 저장 구현 예정

### DIFF
--- a/src/main/java/com/example/fourchelin/domain/search/controller/SearchController.java
+++ b/src/main/java/com/example/fourchelin/domain/search/controller/SearchController.java
@@ -31,6 +31,13 @@ public class SearchController {
         Map<String, List<String>> searchResults = searchService.searchKeyword(member);
         return new RspTemplate<>(HttpStatus.OK, searchResults);
     }
+    @GetMapping("/v2")
+    public RspTemplate<Map<String, List<String>>> searchKeywordV2(@AuthenticationPrincipal UserDetailsImpl userDetails) {
+        // 인증된 유저일 경우 member 객체 가져오기, 아니면 null
+        Member member = (userDetails != null) ? userDetails.getMember() : null;
+        Map<String, List<String>> searchResults = searchService.searchKeywordV2(member);
+        return new RspTemplate<>(HttpStatus.OK, searchResults);
+    }
 
     @GetMapping("/v1/stores")
     public RspTemplate<StorePageResponse> searchStore(@RequestParam String keyword,

--- a/src/main/java/com/example/fourchelin/domain/search/repository/support/PopularKeywordRepositoryCustom.java
+++ b/src/main/java/com/example/fourchelin/domain/search/repository/support/PopularKeywordRepositoryCustom.java
@@ -4,10 +4,11 @@ import com.example.fourchelin.domain.search.entity.PopularKeyword;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 public interface PopularKeywordRepositoryCustom {
     Optional<PopularKeyword> findByKeywordAndTrendDate(String keyword, LocalDate trendDate);
     List<String> findTop10PopularKeywords(LocalDate sevenDaysAgo);
-    List<PopularKeyword> findByTrendDateBetween(LocalDate sevenDaysAgo, LocalDate today);
+    Map<String, Long> findKeywordCountsForLast7Days();
 }

--- a/src/main/java/com/example/fourchelin/domain/search/service/KeywordCacheService.java
+++ b/src/main/java/com/example/fourchelin/domain/search/service/KeywordCacheService.java
@@ -4,12 +4,14 @@ import com.example.fourchelin.domain.search.repository.PopularKeywordRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.cache.Cache;
 import org.springframework.cache.annotation.CachePut;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.cache.CacheManager;
 
 import java.time.LocalDate;
+import java.util.Map;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/com/example/fourchelin/domain/search/service/KeywordCacheService.java
+++ b/src/main/java/com/example/fourchelin/domain/search/service/KeywordCacheService.java
@@ -3,15 +3,13 @@ package com.example.fourchelin.domain.search.service;
 import com.example.fourchelin.domain.search.repository.PopularKeywordRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
 import org.springframework.cache.annotation.CachePut;
-import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.cache.CacheManager;
 
 import java.time.LocalDate;
-import java.util.Map;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/com/example/fourchelin/domain/search/service/SearchService.java
+++ b/src/main/java/com/example/fourchelin/domain/search/service/SearchService.java
@@ -94,11 +94,8 @@ public class SearchService {
         } else {
             result.put("userSearchHistory", List.of());
         }
-        cacheService.displayCache("keywordCounts");
         Map<String, Long> dbKeywordCounts = popularKeywordRepository.findKeywordCountsForLast7Days();
-        System.out.println("dbKeywordCounts : " + dbKeywordCounts);
         Map<String, Long> cacheKeywordCounts = getAllKeywordCountsFromCache();
-        System.out.println("cacheKeywordCounts : " + cacheKeywordCounts);
         Map<String, Long> combinedKeywordCounts = new HashMap<>(dbKeywordCounts);
         if (cacheKeywordCounts != null) {
             cacheKeywordCounts.forEach((keyword, count) ->

--- a/src/main/java/com/example/fourchelin/domain/search/service/SearchService.java
+++ b/src/main/java/com/example/fourchelin/domain/search/service/SearchService.java
@@ -11,6 +11,7 @@ import com.example.fourchelin.domain.store.entity.Store;
 import com.example.fourchelin.domain.store.exception.StoreException;
 import com.example.fourchelin.domain.store.repository.StoreRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -46,8 +47,7 @@ public class SearchService {
     @Transactional
     public StorePageResponse searchStoreV2(String keyword, int page, int size, Member member) {
         searchKeywordAndUpdateSearchHistory(keyword, member);
-        keywordCacheService.saveOrUpdateKeywordCountWithCache(keyword, LocalDate.now());
-        // 캐시 저장 확인
+        keywordCacheService.saveOrUpdateKeywordCountWithCache(keyword);
         cacheService.displayCache("keywordCount");
         Pageable pageable = PageRequest.of(page - 1, size);
         Page<Store> stores = storeRepository.findByKeyword(keyword, pageable);
@@ -74,9 +74,42 @@ public class SearchService {
         } else {
             result.put("userSearchHistory", List.of());
         }
-        // 인기 검색어 목록에서 최근 7일간 상위 카운트 키워드 조회
         LocalDate sevenDaysAgo = LocalDate.now().minusDays(7);
         List<String> popularKeywords = popularKeywordRepository.findTop10PopularKeywords(sevenDaysAgo);
+        result.put("popularKeywords", popularKeywords);
+        return result;
+    }
+
+    public Map<String, List<String>> searchKeywordV2(Member member) {
+        Map<String, List<String>> result = new HashMap<>();
+        if (member != null) {
+            List<SearchHistory> searchHistories = searchHistoryRepository.keywordFindByMember(member);
+            List<String> searchKeywords = searchHistories.stream()
+                    .map(SearchHistory::getKeyword)
+                    .toList();
+            result.put("userSearchHistory", searchKeywords);
+        } else {
+            result.put("userSearchHistory", List.of());
+        }
+        LocalDate today = LocalDate.now();
+        LocalDate sevenDaysAgo = today.minusDays(7);
+        List<PopularKeyword> popularKeywordsFromDb = popularKeywordRepository.findByTrendDateBetween(sevenDaysAgo, today);
+
+        Map<String, Long> combinedKeywordCounts = new HashMap<>();
+        for (PopularKeyword popularKeyword : popularKeywordsFromDb) {
+            combinedKeywordCounts.put(popularKeyword.getKeyword(), popularKeyword.getSearchCount());
+        }
+        Map<String, Long> keywordCountsFromCache = getAllKeywordCountsFromCache();
+        if (keywordCountsFromCache != null) {
+            keywordCountsFromCache.forEach((keyword, count) ->
+                    combinedKeywordCounts.merge(keyword, count, Long::sum)
+            );
+        }
+        List<String> popularKeywords = combinedKeywordCounts.entrySet().stream()
+                .sorted((e1, e2) -> Long.compare(e2.getValue(), e1.getValue()))
+                .limit(10)
+                .map(Map.Entry::getKey)
+                .toList();
         result.put("popularKeywords", popularKeywords);
         return result;
     }
@@ -108,5 +141,10 @@ public class SearchService {
             PopularKeyword newPopularKeyword = new PopularKeyword(keyword, today);
             popularKeywordRepository.save(newPopularKeyword);
         }
+    }
+
+    @Cacheable(value = "keywordCountsByDate")
+    public Map<String, Long> getAllKeywordCountsFromCache() {
+        return null;
     }
 }


### PR DESCRIPTION
## 🔎 작업 내용
-  In-memory Cache를 적용한 v2 인기검색어 조회 기능 추가
-  v2 인기검색어 조회 테스트
- DB에서 7일간 조회 데이터와 현재 캐시에 들어있는 데이터를 뽑아서 병합하여 최신 데이터를 반환

## ➕ 이슈 링크
- #28 

## 📸 스크린샷(선택)

![image](https://github.com/user-attachments/assets/50d3b2d8-634f-4679-9b8d-21fba8870add)
![image](https://github.com/user-attachments/assets/5feb6904-4abc-4528-85a7-78257ef1477b)

## 📝 체크리스트
- [x] 브랜치 이름은 `issue/이슈번호` 형식으로 작성했는가?
- [x] 커밋 메시지는 `[#이슈번호] Feat: 커밋 내용` 형식으로 작성했는가?
- [x] 불필요한 주석은 제거했는가?
- [ ] 코드 리뷰어의 피드백을 반영했는가?
- [x] 테스트를 진행했는가?
- [ ] 테스트 코드를 작성했는가?